### PR TITLE
validation이 적용된 input 구현

### DIFF
--- a/src/pages/apply/UserInfo.tsx
+++ b/src/pages/apply/UserInfo.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useForm, DeepRequired, FieldErrorsImpl } from 'react-hook-form';
+import { SETTINGS, GENDER } from '../../utils/input';
+import { FormControlLabel, Radio, RadioGroup } from '@mui/material';
+import TextField from '@mui/material/TextField';
+
+interface IFormData {
+  [key: string]: string;
+  name: string;
+  gender: typeof GENDER.FEMALE | typeof GENDER.MALE;
+  dateOfBirth: string;
+  address: string;
+  phone: string;
+  email: string;
+}
+
+function UserInfo() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    setValue,
+    clearErrors,
+  } = useForm<IFormData>();
+
+  const handleValid = (data: IFormData) => {
+    console.log(data);
+  };
+
+  return (
+    <Form onSubmit={handleSubmit(handleValid)}>
+      {SETTINGS.map(({ key, title, placeholder, readOnly, option }) => {
+        return (
+          <InputWrapper key={key}>
+            <InputTitle>{title}</InputTitle>
+            <TextField
+              {...register(key, option)}
+              autoComplete='off'
+              id='standard-error-helper-text'
+              variant='standard'
+              placeholder={placeholder}
+              error={!!errors[key]}
+              helperText={getErrorMessage(errors, key)}
+              inputProps={{ readOnly }}
+              onClick={
+                readOnly
+                  ? () => {
+                      setValue(key, '미국');
+                      clearErrors(key);
+                    }
+                  : undefined
+              }
+            />
+          </InputWrapper>
+        );
+      })}
+      <InputWrapper>
+        <InputTitle>{GENDER.TITLE}</InputTitle>
+        <RadioWrapper row defaultValue={GENDER.FEMALE}>
+          <FormControlLabel
+            value={GENDER.FEMALE}
+            label={GENDER.FEMALE}
+            control={<Radio {...register(GENDER.KEY)} />}
+          />
+          <FormControlLabel
+            value={GENDER.MALE}
+            label={GENDER.MALE}
+            control={<Radio {...register(GENDER.KEY)} />}
+          />
+        </RadioWrapper>
+      </InputWrapper>
+      <Button>제출</Button>
+    </Form>
+  );
+}
+
+export default UserInfo;
+
+function getErrorMessage(
+  errors: FieldErrorsImpl<DeepRequired<IFormData>>,
+  key: string,
+): string | false {
+  if (typeof errors[key]?.message === 'string') {
+    return errors[key]?.message + '';
+  }
+
+  return false;
+}
+
+const Form = styled.form`
+  width: 500px;
+  display: flex;
+  flex-direction: column;
+  margin-top: 200px;
+  margin-left: 300px;
+
+  > :nth-child(1) {
+    order: 1;
+  }
+  > :nth-child(2) {
+    order: 3;
+  }
+  > :nth-child(3) {
+    order: 4;
+  }
+  > :nth-child(4) {
+    order: 5;
+  }
+  > :nth-child(5) {
+    order: 6;
+  }
+  > :nth-child(6) {
+    order: 2;
+  }
+  > * {
+    order: 7;
+  }
+`;
+
+const InputWrapper = styled.div``;
+
+const InputTitle = styled.p`
+  font-weight: 600;
+`;
+
+const RadioWrapper = styled(RadioGroup)`
+  display: flex;
+`;
+
+const Button = styled.button`
+  margin-top: 30px;
+`;

--- a/src/pages/apply/index.tsx
+++ b/src/pages/apply/index.tsx
@@ -1,60 +1,6 @@
 import React from 'react';
-import { DeepRequired, FieldErrorsImpl, FieldValues, useForm } from 'react-hook-form';
-import styled from 'styled-components';
-import TextField from '@mui/material/TextField';
+import UserInfo from './UserInfo';
 
-function Apply() {
-  const {
-    register,
-    handleSubmit,
-    formState: { errors },
-  } = useForm();
-
-  const handleValid = () => {
-    return null;
-  };
-
-  const DATE_OF_BIRTH = 'dateOfBirth';
-
-  return (
-    <Form onSubmit={handleSubmit(handleValid)}>
-      <TextField
-        {...register(DATE_OF_BIRTH, {
-          required: true,
-          pattern: {
-            value: /^\d{4}.(0[1-9]|1[012]).(0[1-9]|[12][0-9]|3[01])$/,
-            message: 'YYYY.MM.DD 형식에 맞게 입력해주세요.',
-          },
-        })}
-        id='standard-error-helper-text'
-        label='생년월일'
-        variant='standard'
-        error={!!errors[DATE_OF_BIRTH]}
-        helperText={getErrorMessage(errors, DATE_OF_BIRTH)}
-      />
-      <button>제출</button>
-    </Form>
-  );
+export default function index() {
+  return <UserInfo />;
 }
-
-export default Apply;
-
-function getErrorMessage(
-  errors: FieldErrorsImpl<DeepRequired<FieldValues>>,
-  key: string,
-): string | false {
-  if (typeof errors[key]?.message === 'string') {
-    return errors[key]?.message + '';
-  }
-
-  return false;
-}
-
-const Form = styled.form`
-  width: 300px;
-  display: flex;
-  flex-direction: column;
-  margin-top: 200px;
-  margin-left: 300px;
-  gap: 20px;
-`;

--- a/src/pages/apply/index.tsx
+++ b/src/pages/apply/index.tsx
@@ -1,7 +1,60 @@
 import React from 'react';
+import { DeepRequired, FieldErrorsImpl, FieldValues, useForm } from 'react-hook-form';
+import styled from 'styled-components';
+import TextField from '@mui/material/TextField';
 
 function Apply() {
-  return <div>Apply</div>;
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm();
+
+  const handleValid = () => {
+    return null;
+  };
+
+  const DATE_OF_BIRTH = 'dateOfBirth';
+
+  return (
+    <Form onSubmit={handleSubmit(handleValid)}>
+      <TextField
+        {...register(DATE_OF_BIRTH, {
+          required: true,
+          pattern: {
+            value: /^\d{4}.(0[1-9]|1[012]).(0[1-9]|[12][0-9]|3[01])$/,
+            message: 'YYYY.MM.DD 형식에 맞게 입력해주세요.',
+          },
+        })}
+        id='standard-error-helper-text'
+        label='생년월일'
+        variant='standard'
+        error={!!errors[DATE_OF_BIRTH]}
+        helperText={getErrorMessage(errors, DATE_OF_BIRTH)}
+      />
+      <button>제출</button>
+    </Form>
+  );
 }
 
 export default Apply;
+
+function getErrorMessage(
+  errors: FieldErrorsImpl<DeepRequired<FieldValues>>,
+  key: string,
+): string | false {
+  if (typeof errors[key]?.message === 'string') {
+    return errors[key]?.message + '';
+  }
+
+  return false;
+}
+
+const Form = styled.form`
+  width: 300px;
+  display: flex;
+  flex-direction: column;
+  margin-top: 200px;
+  margin-left: 300px;
+  gap: 20px;
+`;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,0 @@
-export default '';

--- a/src/utils/input/index.ts
+++ b/src/utils/input/index.ts
@@ -1,0 +1,73 @@
+import { NAME_VALIDATION, DOB_VALIDATION, PHONE_VALIDATION, EMAIL_VALIDATION } from './validation';
+
+export const SETTINGS = [
+  {
+    key: 'name',
+    title: '이름',
+    placeholder: '홍길동',
+    readOnly: false,
+    option: {
+      required: true,
+      pattern: {
+        value: NAME_VALIDATION,
+        message: '한글로 이름을 입력해주세요.',
+      },
+    },
+  },
+  {
+    key: 'dateOfBirth',
+    title: '생년월일',
+    placeholder: 'YYYY.MM.DD',
+    readOnly: false,
+    option: {
+      required: true,
+      pattern: {
+        value: DOB_VALIDATION,
+        message: 'YYYY.MM.DD 형식에 맞게 입력해주세요.',
+      },
+    },
+  },
+  {
+    key: 'address',
+    title: '거주지역',
+    placeholder: '거주지역 선택',
+    readOnly: true,
+    option: {
+      required: true,
+      pattern: undefined,
+    },
+  },
+  {
+    key: 'phone',
+    title: '연락처',
+    placeholder: '"-" 없이 입력해 주세요',
+    readOnly: false,
+    option: {
+      required: true,
+      pattern: {
+        value: PHONE_VALIDATION,
+        message: '"-" 없이 11자리 숫자만 입력해주세요.',
+      },
+    },
+  },
+  {
+    key: 'email',
+    title: '이메일',
+    placeholder: 'abc@abc.com',
+    readOnly: false,
+    option: {
+      required: true,
+      pattern: {
+        value: EMAIL_VALIDATION,
+        message: '"@", ".com"을 필수로 입력해주세요.',
+      },
+    },
+  },
+] as const;
+
+export const GENDER = {
+  KEY: 'gender',
+  TITLE: '성별',
+  FEMALE: '여자',
+  MALE: '남자',
+} as const;

--- a/src/utils/input/validation.ts
+++ b/src/utils/input/validation.ts
@@ -1,0 +1,9 @@
+export const NAME_VALIDATION = /^[가-힣]+$/;
+
+export const DOB_VALIDATION =
+  /(19[0-9]{2}|20[0-1][0-9]|202[0-2]).(0[1-9]|1[012]).(0[1-9]|[12][0-9]|3[01])$/;
+
+export const PHONE_VALIDATION = /^01([0|1|6|7|8|9])([0-9]{4})([0-9]{4})$/;
+
+export const EMAIL_VALIDATION =
+  /^[A-Za-z0-9]([-_.]?[A-Za-z0-9])*@[A-Za-z0-9]([-_.]?[A-Za-z0-9])*\.com$/i;


### PR DESCRIPTION
# 개요
- 지원 페이지의 이름, 성별, 생년월일, 거주지역, 연락처, 이메일 input들의 validation을 react-hook-form을 사용하여 구현.
- input은 mui를 사용함.

# 추가 구현 예정
- 전체적인 레이아웃과 스타일은 합칠 때 적용할 예정.
- 거주지역 선택하는 셀렉터 컴포넌트 만들어서 붙여야 됨.