### PR TITLE
랜딩페이지 구현

### DIFF
--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -1,9 +1,84 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import MenuBar from './menuBar';
 import Status from '../../components/applicants/Status';
 
+import mockdata from '../../mocks/applicant.json';
+import { ORDER_CONSTANTS } from '../../utils/constants/data';
+import { MockCandidates } from '../../store/types';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import {
+  allApplicantState,
+  seriesState,
+  pageState,
+  applicantSelector,
+  searchSelector,
+  sortApplicantSelector,
+  pageNationSelector,
+} from '../../store';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+const {
+  ORDER_ID,
+  ORDER_NAME,
+  ORDER_APPLIED_AT,
+  ORDER_GENDER,
+  ORDER_BIRTH,
+  ORDER_EMAIL,
+  ORDER_REGION,
+} = ORDER_CONSTANTS;
+
 export default function Admin() {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const [applicants, setApplicants] = useRecoilState<MockCandidates | any>(allApplicantState);
+  const [series, setSeries] = useRecoilState<number>(seriesState);
+  const [page, setPage] = useRecoilState<number>(pageState);
+  const [order, setOrder] = React.useState<string>(ORDER_ID);
+
+  const seriesSelect = applicantSelector(series);
+  const searchSelect = searchSelector({ applicants: seriesSelect });
+  const sortSelect = sortApplicantSelector({ applicants: searchSelect, order: order });
+  const pageSelect = pageNationSelector({ applicants: sortSelect });
+  const sortedApplicants = useRecoilValue(sortSelect);
+  const pagedApplicants = useRecoilValue(pageSelect);
+
+  const pageRange = Math.ceil(sortedApplicants.length / 10);
+
+  const handleSeriesClick = (series: React.SetStateAction<number>) => {
+    setSeries(series);
+    setPage(1);
+  };
+  const handleSortedClick = (orderKey: React.SetStateAction<string>) => {
+    setOrder(orderKey);
+  };
+  const handlePageClick = (page: React.SetStateAction<number>) => {
+    setPage(page);
+  };
+
+  const PageList = () => {
+    const pageNumber = [];
+    for (let i = 1; i <= pageRange; i++) {
+      pageNumber.push(
+        <button key={i} onClick={() => handlePageClick(i)}>
+          {i}
+        </button>,
+      );
+    }
+    return pageNumber;
+  };
+
+  useEffect(() => {
+    if (!location.state) {
+      alert('접근 권한이 없습니다.');
+      navigate('/');
+    }
+  }, []);
+
+  useEffect(() => {
+    setApplicants(mockdata.applicants);
+  }, []);
   return (
     <Wrapper>
       <Header>AI 학습용 교통 데이터 수집을 위한 클라우드 워커 지원 현황</Header>

--- a/src/pages/landing/index.tsx
+++ b/src/pages/landing/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Button } from '@mui/material';
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
+import { fontSize } from '@mui/system';
 
 export default function Landing() {
   const navigate = useNavigate();
@@ -9,10 +10,20 @@ export default function Landing() {
   return (
     <Wrapper>
       <ButtonWrapper>
-        <Button sx={{ p: 4 }} size='large' onClick={() => navigate('/apply')}>
-          AI 학습용 데이터 크라우드 워커 지원하러가기
+        <Button
+          sx={{ p: 6 }}
+          style={{ backgroundColor: 'white', fontSize: '18px' }}
+          onClick={() => navigate('/apply')}
+        >
+          AI 학습용 데이터
+          <br /> 크라우드 워커
+          <br /> 지원하러가기
         </Button>
-        <Button sx={{ p: 4 }} size='large' onClick={() => navigate('/login')}>
+        <Button
+          sx={{ p: 6 }}
+          style={{ marginLeft: 'auto', backgroundColor: 'white', fontSize: '18px' }}
+          onClick={() => navigate('/login')}
+        >
           관리자 로그인
         </Button>
       </ButtonWrapper>
@@ -31,7 +42,4 @@ const Wrapper = styled.div`
 const ButtonWrapper = styled.div`
   width: 50%;
   display: flex;
-  flex-direction: column;
-  background: white;
-  border-radius: 10px;
 `;

--- a/src/pages/landing/index.tsx
+++ b/src/pages/landing/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Button } from '@mui/material';
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
-import { fontSize } from '@mui/system';
+import { borderRadius, fontSize } from '@mui/system';
 
 export default function Landing() {
   const navigate = useNavigate();
@@ -12,7 +12,7 @@ export default function Landing() {
       <ButtonWrapper>
         <Button
           sx={{ p: 6 }}
-          style={{ backgroundColor: 'white', fontSize: '18px' }}
+          style={{ backgroundColor: 'white', fontSize: '18px', borderRadius: '12px' }}
           onClick={() => navigate('/apply')}
         >
           AI 학습용 데이터
@@ -21,7 +21,12 @@ export default function Landing() {
         </Button>
         <Button
           sx={{ p: 6 }}
-          style={{ marginLeft: 'auto', backgroundColor: 'white', fontSize: '18px' }}
+          style={{
+            marginLeft: 'auto',
+            backgroundColor: 'white',
+            fontSize: '18px',
+            borderRadius: '12px',
+          }}
           onClick={() => navigate('/login')}
         >
           관리자 로그인

--- a/src/pages/landing/index.tsx
+++ b/src/pages/landing/index.tsx
@@ -1,7 +1,37 @@
 import React from 'react';
+import { Button } from '@mui/material';
+import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
 
-function Landing() {
-  return <div>Landing</div>;
+export default function Landing() {
+  const navigate = useNavigate();
+
+  return (
+    <Wrapper>
+      <ButtonWrapper>
+        <Button sx={{ p: 4 }} size='large' onClick={() => navigate('/apply')}>
+          AI 학습용 데이터 크라우드 워커 지원하러가기
+        </Button>
+        <Button sx={{ p: 4 }} size='large' onClick={() => navigate('/login')}>
+          관리자 로그인
+        </Button>
+      </ButtonWrapper>
+    </Wrapper>
+  );
 }
 
-export default Landing;
+const Wrapper = styled.div`
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #ddd;
+`;
+
+const ButtonWrapper = styled.div`
+  width: 50%;
+  display: flex;
+  flex-direction: column;
+  background: white;
+  border-radius: 10px;
+`;

--- a/src/pages/landing/index.tsx
+++ b/src/pages/landing/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Button } from '@mui/material';
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
-import { borderRadius, fontSize } from '@mui/system';
 
 export default function Landing() {
   const navigate = useNavigate();

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,32 +1,65 @@
-import React from 'react';
+import React, { ChangeEvent, FormEvent, useState } from 'react';
 import { Box, Button, TextField, Typography } from '@mui/material';
 import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
+
+const admin = {
+  id: 'admin',
+  password: '1234',
+};
 
 export default function Login() {
+  const [id, setId] = useState<string>('');
+  const [password, setPassword] = useState<string>('');
+  const navigate = useNavigate();
+
+  const handleIdChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setId(event.target.value);
+  };
+
+  const handlePasswordChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setPassword(event.target.value);
+  };
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+
+    if (id != admin.id || password != admin.password) {
+      alert('아이디 또는 비밀번호가 틀립니다.');
+      return;
+    }
+
+    navigate('/admin', { state: { id, password } });
+  };
+
   return (
     <Wrapper>
-      <Form>
+      <Form onSubmit={handleSubmit}>
         <Container sx={{ p: 8, pt: 5, pb: 5 }}>
           <Typography sx={{ pb: 2 }}>관리자 로그인</Typography>
           <TextField
             type='text'
-            id='outlined-basic'
             label='로그인'
             variant='outlined'
             autoComplete='off'
             size='small'
             sx={{ mb: 1 }}
+            value={id}
+            onChange={handleIdChange}
           />
           <TextField
             type='password'
-            id='outlined-basic'
             label='패스워드'
             variant='outlined'
             autoComplete='off'
             size='small'
             sx={{ mb: 1 }}
+            value={password}
+            onChange={handlePasswordChange}
           />
-          <Button variant='contained'>로그인</Button>
+          <Button variant='contained' type='submit'>
+            로그인
+          </Button>
         </Container>
       </Form>
     </Wrapper>

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Box, Button, TextField, Typography } from '@mui/material';
+import styled from 'styled-components';
+
+export default function Login() {
+  return (
+    <Wrapper>
+      <Form>
+        <Container sx={{ p: 8, pt: 5, pb: 5 }}>
+          <Typography sx={{ pb: 2 }}>관리자 로그인</Typography>
+          <TextField
+            type='text'
+            id='outlined-basic'
+            label='로그인'
+            variant='outlined'
+            autoComplete='off'
+            size='small'
+            sx={{ mb: 1 }}
+          />
+          <TextField
+            type='password'
+            id='outlined-basic'
+            label='패스워드'
+            variant='outlined'
+            autoComplete='off'
+            size='small'
+            sx={{ mb: 1 }}
+          />
+          <Button variant='contained'>로그인</Button>
+        </Container>
+      </Form>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #ddd;
+`;
+
+const Form = styled.form`
+  min-width: 400px;
+  background-color: white;
+  border-radius: 12px;
+`;
+
+const Container = styled(Box)`
+  display: flex;
+  flex-direction: column;
+`;

--- a/src/routes/DefaultRouter.tsx
+++ b/src/routes/DefaultRouter.tsx
@@ -4,6 +4,7 @@ import AdminLayout from '../layouts/AdminLayout';
 import Admin from '../pages/admin';
 import Apply from '../pages/apply';
 import Landing from '../pages/landing';
+import Login from '../pages/login';
 
 function DefaultRouter() {
   return (
@@ -13,6 +14,7 @@ function DefaultRouter() {
       <Route element={<AdminLayout />}>
         <Route path='/admin' element={<Admin />} />
       </Route>
+      <Route path='/login' element={<Login />} />
     </Routes>
   );
 }


### PR DESCRIPTION
# 개요
랜딩페이지에서 지원하기 이동 
랜딩페이지에서 관리자 로그인 이동

관리자 페이지에서 location.state가 없으면 메인으로 이동하게 구현

# 구현내용
랜딩페이지
<img width="1440" alt="스크린샷 2022-07-27 오전 11 31 18" src="https://user-images.githubusercontent.com/40565619/181147960-097eeb51-ee70-4f80-bfc2-ecc03405a033.png">

관리자 로그인 페이지
<img width="674" alt="스크린샷 2022-07-27 오전 11 33 59" src="https://user-images.githubusercontent.com/40565619/181148235-e4447e35-06af-4cdd-9345-93428920bdf1.png">

