### PR TITLE
지원자 현황 테이블 페이지네이션 구현

### DIFF
--- a/src/components/applicants/Status.tsx
+++ b/src/components/applicants/Status.tsx
@@ -41,10 +41,14 @@ function Status() {
 
 export default Status;
 
-const Container = styled.section``;
+const Container = styled.section`
+  width: 100%;
+  margin-top: 24px;
+`;
 const StyledPagination = styled(Pagination)`
-  position: absolute;
-  bottom: 24px;
-  left: 50%;
-  transform: translateX(-50%);
+  width: 100%;
+  margin-top: 24px;
+  & > ul:first-child {
+    justify-content: center;
+  }
 `;

--- a/src/components/applicants/Status.tsx
+++ b/src/components/applicants/Status.tsx
@@ -4,20 +4,37 @@ import Table from './Table';
 import styled from 'styled-components';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import {
-  totalSeriesCountState,
-  selectedSeriesState,
   applicantsBySeries,
+  pageState,
+  rowsPerPageState,
+  totalApplicantsCount,
+  totalSeriesCountState,
 } from '../../mocks/status/recoil';
+import { Pagination } from '@mui/material';
 
 function Status() {
-  const [totalSeriesCount] = useRecoilState(totalSeriesCountState);
-  const [selectedSeries] = useRecoilState(selectedSeriesState);
-  const applicants = useRecoilValue(applicantsBySeries(selectedSeries));
+  const totalSeriesCount = useRecoilValue(totalSeriesCountState);
+  const applicantCount = useRecoilValue(totalApplicantsCount);
+  const [applicants, setApplicants] = useRecoilState(applicantsBySeries);
+  const [page, setPage] = useRecoilState(pageState);
+  const rowsPerPage = useRecoilValue(rowsPerPageState);
+  const maxPage = Math.ceil(applicantCount / rowsPerPage);
+
+  const handleChangePage = (event: React.ChangeEvent<unknown>, page: number) => {
+    setPage(page);
+  };
 
   return (
     <Container>
       <Tab length={totalSeriesCount} />
       <Table applicants={applicants} />
+      <StyledPagination
+        count={maxPage}
+        page={page}
+        onChange={handleChangePage}
+        variant='outlined'
+        shape='rounded'
+      />
     </Container>
   );
 }
@@ -25,3 +42,9 @@ function Status() {
 export default Status;
 
 const Container = styled.section``;
+const StyledPagination = styled(Pagination)`
+  position: absolute;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+`;

--- a/src/components/applicants/Tab.tsx
+++ b/src/components/applicants/Tab.tsx
@@ -48,5 +48,4 @@ export default Tab;
 
 const StyledMuiTab = styled(MuiTab)`
   flex: 1;
-  min-width: 160px;
 `;

--- a/src/components/applicants/TableRow.tsx
+++ b/src/components/applicants/TableRow.tsx
@@ -13,7 +13,7 @@ function TableRow({ applicant }: TableRowProps) {
       <MuiTableCell align='center'>{applicant.number}</MuiTableCell>
       <MuiTableCell align='center'>{applicant.appliedAt}</MuiTableCell>
       <MuiTableCell align='center'>{applicant.name}</MuiTableCell>
-      <MuiTableCell align='center'>{applicant.sex}</MuiTableCell>
+      <MuiTableCell align='center'>{applicant.gender}</MuiTableCell>
       <MuiTableCell align='center'>{applicant.dateOfBirth}</MuiTableCell>
       <MuiTableCell align='center'>{applicant.phone}</MuiTableCell>
       <MuiTableCell align='center'>{applicant.email}</MuiTableCell>

--- a/src/mocks/status/recoil.ts
+++ b/src/mocks/status/recoil.ts
@@ -1,23 +1,44 @@
-import { atom, selectorFamily } from 'recoil';
+import { atom, selector } from 'recoil';
 import { MOCK_APPLICANTS } from './table';
+import { MockApplicant } from './type';
 
 const applicantsState = atom({
   key: 'applicantsState',
   default: MOCK_APPLICANTS,
 });
 
-const applicantsBySeries = selectorFamily({
+const totalApplicantsCount = selector({
+  key: 'totalApplicantsCount',
+  get: ({ get }) => {
+    const origin = MOCK_APPLICANTS;
+    const series = get(selectedSeriesState);
+    const filtered = origin.filter((applicant) => applicant.series === series);
+    return filtered.length;
+  },
+});
+
+const applicantsBySeries = selector({
   key: 'applicantsBySeries',
-  get:
-    (series) =>
-    ({ get }) => {
-      return get(applicantsState).filter((applicant) => applicant.series === series);
-    },
+  get: ({ get }) => {
+    const series = get(selectedSeriesState);
+    const filteredApplicants = get(applicantsState).filter(
+      (applicant) => applicant.series === series,
+    );
+    const pagedApplicants = (applicants: MockApplicant[]) => {
+      const page = get(pageState);
+      const rowsPerPage = get(rowsPerPageState);
+      const start = (page - 1) * rowsPerPage;
+      const end = start + rowsPerPage;
+      return applicants.slice(start, end);
+    };
+    return pagedApplicants(filteredApplicants);
+  },
+  set: ({ set }, newValue) => set(applicantsState, newValue),
 });
 
 const pageState = atom({
   key: 'pageState',
-  default: 0,
+  default: 1,
 });
 
 const rowsPerPageState = atom({
@@ -40,5 +61,6 @@ export {
   pageState,
   rowsPerPageState,
   selectedSeriesState,
+  totalApplicantsCount,
   totalSeriesCountState,
 };

--- a/src/mocks/status/recoil.ts
+++ b/src/mocks/status/recoil.ts
@@ -1,16 +1,6 @@
 import { atom, selectorFamily } from 'recoil';
 import { MOCK_APPLICANTS } from './table';
 
-const totalSeriesCountState = atom({
-  key: 'totalSeriesCountState',
-  default: 10,
-});
-
-const selectedSeriesState = atom({
-  key: 'selectedSeriesState',
-  default: 1,
-});
-
 const applicantsState = atom({
   key: 'applicantsState',
   default: MOCK_APPLICANTS,
@@ -25,4 +15,30 @@ const applicantsBySeries = selectorFamily({
     },
 });
 
-export { selectedSeriesState, applicantsBySeries, totalSeriesCountState };
+const pageState = atom({
+  key: 'pageState',
+  default: 0,
+});
+
+const rowsPerPageState = atom({
+  key: 'rowsPerPageState',
+  default: 5,
+});
+
+const selectedSeriesState = atom({
+  key: 'selectedSeriesState',
+  default: 1,
+});
+
+const totalSeriesCountState = atom({
+  key: 'totalSeriesCountState',
+  default: 10,
+});
+
+export {
+  applicantsBySeries,
+  pageState,
+  rowsPerPageState,
+  selectedSeriesState,
+  totalSeriesCountState,
+};

--- a/src/mocks/status/table.ts
+++ b/src/mocks/status/table.ts
@@ -11,7 +11,7 @@ function createMockApplicants(series = 10, headcountPerSeries = 10) {
     for (let count = 0; count < headcountPerSeries; count++) {
       const id = series * 1000 + count;
       const name = `김${series}차${count + 1}`;
-      const sex = (count + 1) % 2 === 1 ? '남' : '여';
+      const gender = (count + 1) % 2 === 1 ? '남' : '여';
       const dateOfBirth = 'yyyy-mm-dd';
       const phone = '000-0000-0000';
       const email = 'some@email.com';
@@ -23,7 +23,7 @@ function createMockApplicants(series = 10, headcountPerSeries = 10) {
         id,
         series,
         name,
-        sex,
+        gender,
         dateOfBirth,
         phone,
         email,

--- a/src/mocks/status/type.ts
+++ b/src/mocks/status/type.ts
@@ -3,7 +3,7 @@ export interface MockApplicant {
   series: number;
   appliedAt: string;
   name: string;
-  sex: string;
+  gender: string;
   dateOfBirth: string;
   phone: string;
   email: string;

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -1,94 +1,14 @@
-import React, { useEffect, useState } from 'react';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import React from 'react';
 import styled from 'styled-components';
-
 import MenuBar from './menuBar';
-import mockdata from '../../mocks/applicant.json';
-import { ORDER_CONSTANTS } from '../../utils/constants/data';
-import { MockCandidates } from '../../store/types';
-import {
-  allApplicantState,
-  seriesState,
-  pageState,
-  applicantSelector,
-  searchSelector,
-  sortApplicantSelector,
-  pageNationSelector,
-} from '../../store';
-
-const {
-  ORDER_ID,
-  ORDER_NAME,
-  ORDER_APPLIED_AT,
-  ORDER_GENDER,
-  ORDER_BIRTH,
-  ORDER_EMAIL,
-  ORDER_REGION,
-} = ORDER_CONSTANTS;
+import Status from '../../components/applicants/Status';
 
 export default function Admin() {
-  const [applicants, setApplicants] = useRecoilState<MockCandidates | any>(allApplicantState);
-  const [series, setSeries] = useRecoilState<number>(seriesState);
-  const [page, setPage] = useRecoilState<number>(pageState);
-  const [order, setOrder] = useState<string>(ORDER_ID);
-
-  const seriesSelect = applicantSelector(series);
-  const searchSelect = searchSelector({ applicants: seriesSelect });
-  const sortSelect = sortApplicantSelector({ applicants: searchSelect, order: order });
-  const pageSelect = pageNationSelector({ applicants: sortSelect });
-  const sortedApplicants = useRecoilValue(sortSelect);
-  const pagedApplicants = useRecoilValue(pageSelect);
-
-  const pageRange = Math.ceil(sortedApplicants.length / 10);
-
-  const handleSeriesClick = (series: React.SetStateAction<number>) => {
-    setSeries(series);
-    setPage(1);
-  };
-  const handleSortedClick = (orderKey: React.SetStateAction<string>) => {
-    setOrder(orderKey);
-  };
-  const handlePageClick = (page: React.SetStateAction<number>) => {
-    setPage(page);
-  };
-
-  const PageList = () => {
-    const pageNumber = [];
-    for (let i = 1; i <= pageRange; i++) {
-      pageNumber.push(
-        <button key={i} onClick={() => handlePageClick(i)}>
-          {i}
-        </button>,
-      );
-    }
-    return pageNumber;
-  };
-
-  useEffect(() => {
-    setApplicants(mockdata.applicants);
-  }, []);
   return (
     <Wrapper>
       <Header>AI 학습용 교통 데이터 수집을 위한 클라우드 워커 지원 현황</Header>
       <MenuBar />
-      {/* table */}
-      <br />
-      <button onClick={() => handleSeriesClick(1)}>1차 모집</button>
-      <button onClick={() => handleSeriesClick(2)}>2차 모집</button>
-      <br />
-      <button onClick={() => handleSortedClick(ORDER_ID)}>전체</button>
-      <button onClick={() => handleSortedClick(ORDER_NAME)}>이름</button>
-      <button onClick={() => handleSortedClick(ORDER_APPLIED_AT)}>지원날짜</button>
-      <button onClick={() => handleSortedClick(ORDER_GENDER)}>성별</button>
-      <button onClick={() => handleSortedClick(ORDER_BIRTH)}>생년월일</button>
-      <br />
-      <span>
-        {pagedApplicants.map(
-          (applicant) =>
-            `이름: ${applicant.name} 지원날짜 : ${applicant.appliedAt}  성별 : ${applicant.gender}  생년월일: ${applicant.dateOfBirth} 운송수단: ${applicant.transportation}  지역:${applicant.region} |`,
-        )}
-      </span>
-      <div>{PageList()}</div>
+      <Status />
     </Wrapper>
   );
 }


### PR DESCRIPTION
# 개요
- 선택된 차수의 지원자를 여러 페이지로 분할해서 보여주기
- 어드민 페이지에 연결